### PR TITLE
deluge 1.3.14 and other minor tweeks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:16.04
 MAINTAINER cturra <cturra@gmail.com>
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV DELUGE_VERSION  1.3.13-0~xenial~ppa1
+ENV DELUGE_VERSION  1.3.14-0~xenial~ppa1
 
 # setup and install deluge (key: 249AD24C) from ppa
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 249AD24C                                            \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,14 @@ ENV DELUGE_VERSION  1.3.14-0~xenial~ppa1
 # setup and install deluge (key: 249AD24C) from ppa
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 249AD24C                                            \
  && echo "deb http://ppa.launchpad.net/deluge-team/ppa/ubuntu xenial main" > /etc/apt/sources.list.d/deluge.list \
- && echo "deb http://archive.ubuntu.com/ubuntu/ xenial multiverse" >> /etc/apt/sources.list                      \
+ && echo "deb http://archive.ubuntu.com/ubuntu/ xenial multiverse"        >> /etc/apt/sources.list               \
  && apt-get -q update                               \
  && apt-get -y install supervisor                   \
                        deluged=${DELUGE_VERSION}    \
                        deluge-web=${DELUGE_VERSION} \
+                       p7zip-full                   \
                        unrar                        \
+                       unzip                        \
  && rm -rf /var/lib/apt/lists/*
 
 # supervisor config

--- a/assets/configs/supervisor.conf
+++ b/assets/configs/supervisor.conf
@@ -1,7 +1,7 @@
 [supervisord]
 nodaemon=true
 
-[program:app]
+[program:daemon]
 priority=10
 command=/usr/bin/deluged --do-not-daemonize --config=/data --loglevel=info --logfile=/data/deluged.log
 user=root


### PR DESCRIPTION
the primary driver for this pull request was to upgrade deluge to `1.3.14`. additionally, the following changes were made:

 - (feature) added `p7zip` and `unzip` packages for decompressing files
 - (accuracy) renamed the supervisord program from `app` to `daemon`

deluge release notes: http://dev.deluge-torrent.org/wiki/ReleaseNotes/1.3.14